### PR TITLE
call to know people access to a project

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -2,7 +2,6 @@ from django.conf.urls import include, url
 from rest_framework.urlpatterns import format_suffix_patterns
 from api import views
 
-
 urlpatterns = format_suffix_patterns(
     [
         # TOKEN AUTHENTIFICATION
@@ -21,6 +20,11 @@ urlpatterns = format_suffix_patterns(
             r'^projects/(?P<pk>\d+)$',
             views.ProjectRetrieveUpdateDestroy.as_view(),
             name='projects_detail'
+        ),
+        url(
+            r'^projects/(?P<pk>\d+)/access$',
+            views.ProjectAccessList.as_view(),
+            name='projects_access_list'
         ),
         # ACCESS
         url(

--- a/api/views.py
+++ b/api/views.py
@@ -3,6 +3,7 @@
 from api import models
 from api import serializers
 import django_filters
+from django.shortcuts import get_object_or_404
 
 from rest_framework import generics
 from rest_framework import filters
@@ -52,6 +53,26 @@ class ProjectRetrieveUpdateDestroy(generics.RetrieveUpdateDestroyAPIView):
 
     def get_queryset(self):
         return models.Project.objects.all()
+
+
+class ProjectAccessList(generics.ListAPIView):
+    serializer_class = serializers.AccessSerializer
+
+    def get_queryset(self):
+        # Check if project exist
+        project = get_object_or_404(
+            models.Project,
+            pk=self.kwargs['pk']
+        )
+
+        #Check if user have access to this project
+        get_object_or_404(
+            models.Access,
+            project__id=self.kwargs['pk'], 
+            user__id=self.request.user.id
+        )
+
+        return models.Access.objects.filter(project__id=self.kwargs['pk'])
 
 
 """


### PR DESCRIPTION
closes #1 

I've add a new call `projects/(?P<pk>\d+)/access` to know how have access to a specific project.

The given id need to exist and the user need to have an access to the project to have a respons.