### PR TITLE
call to know labels of a project 

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -31,6 +31,11 @@ urlpatterns = format_suffix_patterns(
             views.ProjectTaskList.as_view(),
             name='projects_tasks_list'
         ),
+        url(
+            r'^projects/(?P<pk>\d+)/labels$',
+            views.ProjectLabelList.as_view(),
+            name='projects_labels_list'
+        ),
         # ACCESS
         url(
             r'^access$',

--- a/api/views.py
+++ b/api/views.py
@@ -94,6 +94,26 @@ class ProjectTaskList(generics.ListAPIView):
 
         return models.Task.objects.filter(project__id=self.kwargs['pk'])
 
+
+class ProjectLabelList(generics.ListAPIView):
+    serializer_class = serializers.LabelSerializer
+
+    def get_queryset(self):
+        # Check if project exist
+        project = get_object_or_404(
+            models.Project,
+            pk=self.kwargs['pk']
+        )
+
+        #Check if user have access to this project
+        get_object_or_404(
+            models.Access,
+            project__id=self.kwargs['pk'],
+            user__id=self.request.user.id
+        )
+
+        return models.Label.objects.filter(project__id=self.kwargs['pk'])
+
 """
 ACCESS
 """


### PR DESCRIPTION
closes #5 

I've add a new call `projects/(?P<pk>\d+)/labels` to know labels of a project